### PR TITLE
Added Reactive Styling for Wiki Page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -24,7 +24,7 @@
 
 body {
   background: var(--primary-background);
-  font-size: 14pt;
+  font-size: clamp(1vw, 14pt, 2vw);
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto;
@@ -43,7 +43,7 @@ body {
 
 h1 {
   margin: 50pt 0 0 0;
-  font-size: 100pt;
+  font-size: clamp(8vw, 100pt, 9vw);
   font-weight: 800;
   font-family: 'Inter', sans-serif;
   color: var(--navy);
@@ -65,7 +65,7 @@ li, ul {
 a {
   color: var(--primary-text);
   font-style: bold;
-  font-size: 20pt;
+  font-size: clamp(2vw, 20pt, 3vw);
   text-decoration: none;
 }
 
@@ -85,7 +85,7 @@ a:hover {
   color: var(--white);
   font-family: 'Roboto Mono', comic-sans, sans-serif;
   font-weight: 300;
-  font-size: 10pt;
+  font-size: clamp(1vw, 10pt, 2vw);
 }
 
 .app-header-link:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -24,7 +24,7 @@
 
 body {
   background: var(--primary-background);
-  font-size: clamp(1vw, 14pt, 2vw);
+  font-size: clamp(10px, 1.75vw, 18pt);
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto;
@@ -42,7 +42,7 @@ body {
 }
 
 h1 {
-  margin: 50pt 0 0 0;
+  margin: clamp(2vh, 5vw, 50pt) 0 0 0;
   font-size: clamp(8vw, 100pt, 9vw);
   font-weight: 800;
   font-family: 'Inter', sans-serif;

--- a/frontend/src/Wiki.css
+++ b/frontend/src/Wiki.css
@@ -20,6 +20,7 @@
 .wiki-content-container {
   display: grid;
   width: 100%;
+  padding-left: 5pt;
 }
 
 .wiki-content-description {
@@ -101,6 +102,10 @@
   font-size: clamp(1vw, 10pt, 2vw);
   border-radius: 2pt;
   border: 0.2px solid var(--primary-border);
+}
+
+.clear-filters {
+  white-space: nowrap;
 }
 
 .publish-date {

--- a/frontend/src/Wiki.css
+++ b/frontend/src/Wiki.css
@@ -27,9 +27,18 @@
   grid-template-columns: 1fr 3fr 1fr;
   border-bottom: 0.5px solid var(--primary-border);
   align-items: center;
-  align-self: start; 
   text-align: left; 
   padding: 10pt 0 5pt 0;
+}
+
+.wiki-content-description.two-columns {
+  grid-template-columns: 1fr 3fr;
+  justify-items: center;
+  gap: 10px;
+}
+
+.wiki-content-description.three-columns {
+  grid-template-columns: 1fr 3fr 1fr;
 }
 
 .wiki-content-description > :nth-child(2) {
@@ -62,8 +71,16 @@
 
 .wiki-filter-section-container {
   display: grid;
+  grid-template-columns: 1fr 3fr;
+  align-items: center;
+  justify-items: center;
 }
 
+.wiki-filter-section-container > :nth-child(2) {
+  text-align: left;
+  justify-self: start;
+  margin-left: 6vw;
+}
 
 .wiki-filter-section-container:first-child {
   border-top: 0.5px solid var(--primary-border);
@@ -78,15 +95,15 @@
 
 .wiki-type-badge {
   display: inline-block;
-  width: 'fit-content';
+  width: fit-content;
   padding: 1.5pt 2.5pt 2pt 2.5pt; /* TODO: Hacky vertical centering of text in border */
   font-family: 'Roboto Mono', comic-sans, sans-serif;
-  font-size: 10pt;
+  font-size: clamp(1vw, 10pt, 2vw);
   border-radius: 2pt;
   border: 0.2px solid var(--primary-border);
 }
 
 .publish-date {
   font-family: 'Roboto Mono', comic-sans, sans-serif;
-  font-size: 12pt;
+  font-size: clamp(1vw, 12pt, 2vw);
 }

--- a/frontend/src/Wiki.jsx
+++ b/frontend/src/Wiki.jsx
@@ -25,7 +25,7 @@ function Wiki() {
         <div className="wiki-nav-container">
           <div className="wiki-content-description two-columns">
             <div> FILTER </div>
-            <div> CLEAR FILTERS </div>
+            <div className="clear-filters"> CLEAR FILTERS </div>
           </div>
           <ul>
             {Object.values(WikiType).map((typeName, idx) => (

--- a/frontend/src/Wiki.jsx
+++ b/frontend/src/Wiki.jsx
@@ -23,7 +23,7 @@ function Wiki() {
       <h1> Blue Nucleus / <span className="h1-subpage"> wiki </span> </h1>
       <div className="wiki-container">
         <div className="wiki-nav-container">
-          <div className="wiki-content-description">
+          <div className="wiki-content-description two-columns">
             <div> FILTER </div>
             <div> CLEAR FILTERS </div>
           </div>
@@ -37,7 +37,7 @@ function Wiki() {
           </ul>
         </div>
         <div className="wiki-content-container">
-          <div className="wiki-content-description">
+          <div className="wiki-content-description three-columns">
             <div> DATE </div>
             <div> NAME </div>
             <div> TYPE </div>


### PR DESCRIPTION
**Key Changes:**
- Used `vw` and `clamp(min, preferred, max)` to achieve reactive styling
- Ensured that the title and menu scale dynamically across the entire app, not just the Wiki Page
- Adjusted the content grid to prevent clipping on smaller screens

**Recommendation for Mobile Layout:**
- Introduce a toggle mechanism for filters, allowing users to show/hide them as needed
- When displayed, the `wiki-nav-container` should stack above the `wiki-content-container` to optimize space on smaller screens